### PR TITLE
Diff without renames.

### DIFF
--- a/git-ftp.py
+++ b/git-ftp.py
@@ -252,7 +252,7 @@ def upload_diff(repo, oldtree, tree, ftp, base):
                have a trailing slash.
 
     """
-    diff = repo.git.diff("--name-status", oldtree.hexsha, tree.hexsha).split("\n")
+    diff = repo.git.diff("--name-status", "--no-renames", oldtree.hexsha, tree.hexsha).split("\n")
     for line in diff:
         if not line: continue
         status, file = line.split("\t", 1)


### PR DESCRIPTION
When the configuration has `diff.renames=true` the --name-status diff can
contain renames, that the following code can not handle.

Since we can't deal with renames on FTP level, we should explicitly use
--no-renames.
