### PR TITLE
"Section not found" error when using -s switch on differently named branch

### DIFF
--- a/git-ftp.py
+++ b/git-ftp.py
@@ -73,7 +73,7 @@ class SectionNotFound(Exception):
     pass
 
 
-def split_pattern(path):
+def split_pattern(path):  # TODO: Improve skeevy code
     path = fnmatch.translate(path).split('\\/')
     for i, p in enumerate(path[:-1]):
         if p:
@@ -302,7 +302,7 @@ def get_ftp_creds(repo, options):
             options.ftp.ssl = False
 
         try:
-            options.ftp.gitftpignore = cfg.get(options.branch, 'gitftpignore')
+            options.ftp.gitftpignore = cfg.get(options.section, 'gitftpignore')
         except ConfigParser.NoOptionError:
             options.ftp.gitftpignore = '.gitftpignore'
     else:


### PR DESCRIPTION
When using -s command line switch, lookup of gitftpignore
info from .git/ftpdata file fails as the switch is ignored
there and the branch name is used. This commit fixes the bug.
