### PR TITLE
Retrying failed uploads and .maintenance file

### DIFF
--- a/git-ftp.py
+++ b/git-ftp.py
@@ -176,7 +176,9 @@ def main():
     if oldtree.hexsha == tree.hexsha:
         logging.info('Nothing to do!')
     else:
+        ftp.storbinary('STOR .maintenance', cStringIO.StringIO('<?php $upgrading = time(); ?>'))
         upload_diff(repo, oldtree, tree, ftp, [base], patterns)
+        ftp.delete('.maintenance')
 
     ftp.storbinary('STOR git-rev.txt', cStringIO.StringIO(commit.hexsha))
     ftp.quit()


### PR DESCRIPTION
Hello,

Two commits.

One that retries on network errors. Had some unstable connections to my servers that needed this.

The other modification is that a .maintenance file gets added when sync starts and removed once done. This is to put Wordpress-powered sites in maintenance mode preventing visitors reaching half-uploaded files. I realize that this might be something that can be configured on a per-remote basis. Let me know if this is of interest at all and I will make changes.